### PR TITLE
Fixed environment variable label

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     expose:
       - 9142
     environment:
-      - PORT=8000
+      - HTTP_PORT=8000
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
I was getting a connection reset error when trying to make a request to the demo. By getting inside the container of the exporter I noticed it uses the environment variable `HTTP_PORT` to specify the port while the docker-compose configuration was using `PORT`.

Are there still plans for this project? I noticed even after the fix nothing shows up in the dashboard.

I'm currently working on a [continuous profiler](https://github.com/rockerbacon/flamegraph-profiler) for Node.js applications and being able to pair it with visualizations on Grafana would be perfect.